### PR TITLE
chore: bump to v0.5.0 — full skills.sh integration parity

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "superskill",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Runtime intelligence layer for AI agent skills — smart routing, collision resolution, and knowledge vault. Works with skills.sh and any installed SKILL.md files.",
   "author": {
     "name": "Permanu (Atharva Pandey)",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-03-25
+
+### Added
+- **Version-pinned skill cache** — Cache paths include version (`name@1.0.0.md`), with LRU eviction at 5MB. Core prefetch skills exempt from eviction. (#3)
+- **Context-aware skill budgeting** — Skills are loaded within a token budget (15% of detected context window, 2k-50k range). Priority-respecting cutoff ensures highest-scored skill always loads. (#10)
+- **Windsurf, Aider, Continue support** — Tool detection and setup for 3 new AI tools (11 total). (#14)
+- **`superskill-cli onboard` command** — Auto-detects AI tools, configures MCP, scans installed skills. Non-interactive for CI/MCP compatibility. (#15)
+- **Skill authoring guide** — CONTRIBUTING.md with authoring docs, SKILL-TEMPLATE.md with triggers field, PR template for skill submissions. (#8)
+- **Full skill directory scanning** — Scanner now covers all 11 AI tool directories (added Windsurf, Aider, Continue, Crush, Droid)
+
+### Changed
+- **Registry version synced to 0.5.0** — Was stuck at 0.3.0 since initial release
+- **Cache uses mtime** — Replaced atime (unreliable on Linux/containers) with mtime for LRU ordering
+- **Error handling improved** — Cache write failures now logged with context, temp files cleaned up on failure
+
+### Removed
+- **Dead backward-compatible exports** — Unused `DOMAINS`, `CATALOG`, `DOMAIN_PRIORITY` static exports removed from catalog.ts
+
 ## [0.4.0] - 2026-03-25
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superskill",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Runtime intelligence layer for AI agent skills — smart routing, collision resolution, and knowledge vault",
   "type": "module",
   "main": "dist/mcp-server.js",

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,5 +1,5 @@
 {
-  "registry_version": "0.3.0",
+  "registry_version": "0.5.0",
   "generated_at": "2026-03-25T00:00:00Z",
   "sources": {
     "ecc": {

--- a/src/commands/skill/catalog.ts
+++ b/src/commands/skill/catalog.ts
@@ -196,14 +196,6 @@ export function getDomainPriority(domainId: string): 'core' | 'extended' | 'refe
   return FALLBACK_PRIORITY[domainId];
 }
 
-// Backward-compatible exports — these delegate to the getter functions
-// NOTE: These are evaluated at import time, so they return the fallback values.
-// Code that needs registry data should use getDomains()/getCatalog() instead.
-export const DOMAINS: SkillDomain[] = FALLBACK_DOMAINS;
-export const CATALOG: CatalogSkill[] = FALLBACK_CATALOG;
-
-export const DOMAIN_PRIORITY: Record<string, 'core' | 'extended' | 'reference'> = FALLBACK_PRIORITY;
-
 // ── Collision Detection ──────────────────────────────
 
 export function detectCollisions(): Collision[] {

--- a/src/lib/registry-loader.test.ts
+++ b/src/lib/registry-loader.test.ts
@@ -65,7 +65,7 @@ describe("registry-loader", () => {
       _setUserRegistryPath(join(testDir, "nonexistent.json"));
 
       const registry = await loadRegistry();
-      expect(registry.registry_version).toBe("0.3.0");
+      expect(registry.registry_version).toBe("0.5.0");
       expect(registry.skills.length).toBeGreaterThanOrEqual(87);
       expect(registry.domains.length).toBe(28);
     });
@@ -86,7 +86,7 @@ describe("registry-loader", () => {
       _setUserRegistryPath(userFile);
 
       const registry = await loadRegistry();
-      expect(registry.registry_version).toBe("0.3.0");
+      expect(registry.registry_version).toBe("0.5.0");
       expect(registry.skills.length).toBeGreaterThanOrEqual(87);
     });
 
@@ -96,7 +96,7 @@ describe("registry-loader", () => {
       _setUserRegistryPath(userFile);
 
       const registry = await loadRegistry();
-      expect(registry.registry_version).toBe("0.3.0");
+      expect(registry.registry_version).toBe("0.5.0");
     });
 
     it("caches the registry in memory", async () => {

--- a/src/lib/skill-scanner.ts
+++ b/src/lib/skill-scanner.ts
@@ -64,12 +64,17 @@ interface SkillDir {
 export function getSkillDirectories(projectDir?: string): SkillDir[] {
   const home = homedir();
   const dirs: SkillDir[] = [
-    // Global skill directories
+    // Global skill directories — all 11 supported AI tools
     { path: resolve(home, ".claude", "skills"), scope: "global", source_tool: "claude" },
     { path: resolve(home, ".cursor", "skills"), scope: "global", source_tool: "cursor" },
     { path: resolve(home, ".codex", "skills"), scope: "global", source_tool: "codex" },
     { path: resolve(home, ".gemini", "skills"), scope: "global", source_tool: "gemini" },
     { path: resolve(home, ".config", "opencode", "skills"), scope: "global", source_tool: "opencode" },
+    { path: resolve(home, ".codeium", "windsurf", "skills"), scope: "global", source_tool: "windsurf" },
+    { path: resolve(home, ".aider", "skills"), scope: "global", source_tool: "aider" },
+    { path: resolve(home, ".continue", "skills"), scope: "global", source_tool: "continue" },
+    { path: resolve(home, ".config", "crush", "skills"), scope: "global", source_tool: "crush" },
+    { path: resolve(home, ".factory", "skills"), scope: "global", source_tool: "droid" },
   ];
 
   // Project-level skill directories

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -60,7 +60,7 @@ function createCtx(): CommandContext {
 }
 
 const server = new Server(
-  { name: "superskill", version: "0.4.0" },
+  { name: "superskill", version: "0.5.0" },
   { capabilities: { tools: {}, resources: {}, prompts: {} } }
 );
 


### PR DESCRIPTION
## Summary

- Bump version 0.4.0 → 0.5.0 across all 4 locations (package.json, plugin.json, mcp-server.ts, registry)
- Skill scanner now covers all 11 AI tool directories (was only 5 — missing Windsurf, Aider, Continue, Crush, Droid)
- Remove dead `DOMAINS`, `CATALOG`, `DOMAIN_PRIORITY` static exports from catalog.ts (zero imports)
- Sync registry_version from stale 0.3.0 to 0.5.0
- CHANGELOG entry for v0.5.0

## Test plan
- [x] `npm run build` — clean
- [x] `npm test` — 906/906 pass
- [x] Registry loader tests updated for new version string